### PR TITLE
Fix crash when no contests exists

### DIFF
--- a/lwimw/context_processors.py
+++ b/lwimw/context_processors.py
@@ -6,6 +6,10 @@ def common(request):
     contests = Contest.objects.order_by('-start')
     for contest in contests:
         contest.can_vote = request.user.is_authenticated() and user_can_vote(request.user, contest.submissions.all())
+    if contests:
+        current_contest = contests[0]
+    else:
+        current_contest = None
     current_contest = contests[0]
     #now = timezone.now()
 


### PR DESCRIPTION
Updated the context processor to not crash with an IndexError when no contests exists.
